### PR TITLE
Feature: Adding hostPrefix concatenation at the request level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ An instance returned by `ServiceClient.create()`.
     - **options** - Options to pass to [`Hoek.reach()`](https://github.com/hapijs/hoek/blob/master/API.md#reachobj-chain-options).
 - **`request(options)`** - Makes an http request.
     - **method** - The HTTP method.
+    - **hostPrefix** - A base prefix that gets prepended to the hostname.
     - **path** - Defaults to `'/'`.
     - **queryParams** - Object containing key-value query parameter values.
     - **pathParams** - Object containing key-value path parameters to replace `{someKey}` value in path with.

--- a/lib/client.js
+++ b/lib/client.js
@@ -25,6 +25,7 @@ const Schema = require('./schema')
 const Hooks = require('./hooks')
 const Request = require('./http/request')
 const Read = require('./http/read')
+const { createBaseUrl } = require('./helpers')
 
 const debug = require('debug')('serviceclient:client')
 
@@ -44,9 +45,9 @@ class ServiceClient {
     if (typeof config.hostname === 'function') {
       config.hostname = config.hostname(servicename, config)
     }
-    const { protocol, hostname, basePath } = config
-    const port = config.port ? `:${config.port}` : ''
-    this._baseUrl = `${protocol}//${hostname}${port}${basePath}`
+
+    const { protocol, hostname, port, basePath } = config
+    this._baseUrl = createBaseUrl(protocol, hostname, basePath, port)
 
     // Configure circuit breaking
     this._circuitState = new CircuitBreakerState({ maxFailures: config.maxFailures, resetTime: config.resetTime })
@@ -71,6 +72,7 @@ class ServiceClient {
 
     const {
       context,
+      hostPrefix,
       path,
       method,
       operation,
@@ -100,11 +102,19 @@ class ServiceClient {
     // Use our own requestId instead of the one request generates.
     const requestId = Cuid()
 
+    let baseUrl
+    if (hostPrefix) {
+      const { protocol, hostname, port, basePath } = config
+      baseUrl = createBaseUrl(protocol, hostname, basePath, port, hostPrefix)
+    } else {
+      baseUrl = this._baseUrl
+    }
+
     // Request options
     let requestOptions = {
       queryParams,
       pathParams,
-      baseUrl: this._baseUrl,
+      baseUrl,
       headers,
       payload,
       redirects,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,11 @@
+'use strict'
+
+function createBaseUrl (protocol, hostname, basePath, port, hostPrefix) {
+  const fixedPrefix = hostPrefix ? `${hostPrefix}.` : ''
+  const fixedPort = port ? `:${port}` : ''
+  return `${protocol}//${fixedPrefix}${hostname}${fixedPort}${basePath}`
+}
+
+module.exports = {
+  createBaseUrl
+}

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -65,6 +65,7 @@ const requestDefaults = {
 
 const requestSchema = Joi.object({
   context: Joi.object().description('Usually the hapi `request`'),
+  hostPrefix: Joi.string(),
   path: Joi.string().default(requestDefaults.path),
   method: Joi.string().required(),
   operation: Joi.string().required().description('Ex: GET_supply_properties_v1'),

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -189,6 +189,11 @@ describe('client', function () {
     it('should merge an empty external config into the global config without error', function () {
       assert.doesNotThrow(() => ServiceClient.mergeConfig())
     })
+
+    it('should throw an error when constructor not given a service name', () => {
+      const SC = require('../../lib/client')
+      assert.throws(() => new SC(), 'A service name is required')
+    })
   })
 
   describe('service-client request', () => {
@@ -249,6 +254,17 @@ describe('client', function () {
       const client = ServiceClient.create('myservice', { hostname: 'myservice.service.local' })
 
       const response = await client.request({ method: 'GET', path: '/v1/test/stuff', queryParams: { id: '123' }, operation: 'GET_v1_test_stuff' })
+
+      assert.equal(response.statusCode, 200, 'is ok.')
+    })
+
+    it('should make a successful request with `hostPrefix`', async function () {
+      Nock('http://prefix.myservice.service.local:80')
+        .get('/v1/test/stuff?id=123')
+        .reply(200, { message: 'success' })
+
+      const client = ServiceClient.create('myservice', { hostname: 'myservice.service.local' })
+      const response = await client.request({ method: 'GET', path: '/v1/test/stuff', queryParams: { id: '123' }, operation: 'GET_v1_test_stuff', hostPrefix: 'prefix' })
 
       assert.equal(response.statusCode, 200, 'is ok.')
     })

--- a/test/unit/helpers.test.js
+++ b/test/unit/helpers.test.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { expect } = require('chai')
+const { createBaseUrl } = require('../../lib/helpers')
+
+describe('helpers', () => {
+  describe('createBaseUrl', () => {
+    it('no host prefix', () => {
+      const expected = 'http://vrbo.com/app'
+      const actual = createBaseUrl('http:', 'vrbo.com', '/app')
+      expect(actual).to.equal(expected)
+    })
+
+    it('host prefix present', () => {
+      const expected = 'http://secure.vrbo.com/app'
+      const actual = createBaseUrl('http:', 'vrbo.com', '/app', null, 'secure')
+      expect(actual).to.equal(expected)
+    })
+
+    it('no port present', () => {
+      const expected = 'http://vrbo.com/app'
+      const actual = createBaseUrl('http:', 'vrbo.com', '/app')
+      expect(actual).to.equal(expected)
+    })
+
+    it('port present', () => {
+      const expected = 'http://vrbo.com:8080/app'
+      const actual = createBaseUrl('http:', 'vrbo.com', '/app', '8080')
+      expect(actual).to.equal(expected)
+    })
+  })
+})


### PR DESCRIPTION
## Description
Adds the ability for a hostPrefix to get prepended to the baseUrl.  This can now happen at the request level and not just at client creation time.  

## Motivation and Context
It allows for a more dynamic ability to redirect requests as necessary based on apps that use subdomain routing techniques.

## How Has This Been Tested?
This was tested internally at Vrbo.  We are using this functionality.  Also, using unit tests to thoroughly cover the new functionality.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
