### PR TITLE
Feature: Allow `false` as a value supplied to `readOptions.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ Returns a promise that resolves into the payload in the form of a Buffer or (opt
 - **options** - A configuration object
     - **timeout** - The number of milliseconds to wait while reading data before
     aborting handling of the response. Defaults to unlimited.
-    - **json** - A value indicating how to try to parse the payload as JSON. Defaults to `undefined` meaning no parse logic.
-        - **true**, 'smart' - Only try `JSON.parse` if the response indicates a JSON content-type.
-        - **strict** - As 'smart', except returns an error for non-JSON content-type.
+    - **json** - A value indicating how to try to parse the payload as JSON. Defaults to `true`.
+        - **true** - Only try `JSON.parse` if the response indicates a JSON content-type.
+        - **false** - Do not try `JSON.parse` on the response at all.
+        - **strict** - Same as `true`, except throws an error for non-JSON content-type.
         - **force** - Try `JSON.parse` regardless of the content-type header.
     - **gunzip** - A value indicating the behavior to adopt when the payload is gzipped. Defaults to `undefined` meaning no gunzipping.
         - **true** - Only try to gunzip if the response indicates a gzip content-encoding.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -81,7 +81,7 @@ const requestSchema = Joi.object({
   read: Joi.bool().default(requestDefaults.read),
   readOptions: Joi.object({
     timeout: Joi.number().default(requestDefaults.readOptions.timeout),
-    json: Joi.valid(true, 'strict', 'force').default(requestDefaults.readOptions.json),
+    json: Joi.valid(true, false, 'strict', 'force').default(requestDefaults.readOptions.json),
     maxBytes: Joi.number(),
     gunzip: Joi.valid(true, false, 'force').default(requestDefaults.readOptions.gunzip)
   }).default(requestDefaults.readOptions),

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "eslint lib test",
     "mocha": "mocha test/unit/*.js test/unit/**/*.js",
     "nyc": "nyc --reporter=text --reporter=text-summary --reporter=html --report-dir=docs/reports/coverage npm run mocha",
-    "postnyc": "nyc check-coverage --statements 99 --branches 95 --functions 100 --lines 98"
+    "postnyc": "nyc check-coverage --statements 99 --branches 97 --functions 100 --lines 99"
   },
   "repository": {
     "type": "git",

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -296,6 +296,21 @@ describe('client', function () {
       assert.instanceOf(response.payload, Buffer)
     })
 
+    it('should NOT parse a response, even with json content-type headers', async function () {
+      Nock('http://myservice.service.local:80')
+        .defaultReplyHeaders({
+          'Content-Type': 'application/json'
+        })
+        .get('/v1/test/stuff')
+        .reply(200, 'this-is-not-json')
+
+      const client = ServiceClient.create('myservice', { hostname: 'myservice.service.local' })
+
+      const response = await client.request({ method: 'GET', path: '/v1/test/stuff', operation: 'GET_v1_test_stuff', readOptions: { json: false } })
+
+      assert.equal(response.payload, 'this-is-not-json')
+    })
+
     it('should throw an error when attempting to parse a payload that is expected to be JSON', async function () {
       Nock('http://myservice.service.local:80')
         .defaultReplyHeaders({


### PR DESCRIPTION
This allows a user to opt out entirely from parsing a response payload, irrespective of the content-type headers on the response.

## Description
* Add `false` as a valid option on the schema
* Refine docs to reflect the schema changes

## Motivation and Context
An API is returning non-JSON data, even with the content-type header indicating json. I would like to bypass the parsing behavior entirely, no matter the content-type headers that are respected when providing `true`.

## How Has This Been Tested?
A test has been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
