### PR TITLE
Fix: add hook debug statements

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -76,7 +76,7 @@ async function init (options) {
       // wait for the pending hook promises to resolve
       const results = await Promise.all(hookPromises)
 
-      debug('%s(): results from hooks: %j', hookName, results);
+      debug('%s(): results from hooks: %j', hookName, results)
 
       // for the `request` hook, merge and return options data
       if (hookName === 'request') {
@@ -86,18 +86,18 @@ async function init (options) {
           Hoek.merge(finalData, result)
         })
 
-        debug('%s(): merged hook data: %j', hookName, finalData);
+        debug('%s(): merged hook data: %j', hookName, finalData)
 
         return finalData
       } else
 
       // for the `response` hook, return the first non-falsy value
       if (hookName === 'response') {
-        const response = results.find((result) => result);
+        const response = results.find((result) => result)
 
-        debug('%s(): first result: %j', hookName, response);
+        debug('%s(): first result: %j', hookName, response)
 
-        return response;
+        return response
       }
     }
   })

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -76,6 +76,8 @@ async function init (options) {
       // wait for the pending hook promises to resolve
       const results = await Promise.all(hookPromises)
 
+      debug('%s(): results from hooks: %j', hookName, results);
+
       // for the `request` hook, merge and return options data
       if (hookName === 'request') {
         // merge results of returned hook data
@@ -83,12 +85,19 @@ async function init (options) {
         results.forEach((result) => {
           Hoek.merge(finalData, result)
         })
+
+        debug('%s(): merged hook data: %j', hookName, finalData);
+
         return finalData
       } else
 
       // for the `response` hook, return the first non-falsy value
       if (hookName === 'response') {
-        return results.find((result) => result)
+        const response = results.find((result) => result);
+
+        debug('%s(): first result: %j', hookName, response);
+
+        return response;
       }
     }
   })


### PR DESCRIPTION
This change allows for greater visibility when debugging. It adds debug statements to critical points in the hook code where it's confusing to understand what's happening.