### PR TITLE
Fix: strip 'content-length' header from all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A general purpose HTTP client built with extensibility in mind.
     * [Available Plugins](#available-plugins)
     * [Plugin structure](#plugin-structure)
     * [Writing your own plugin](#writing-your-own-plugin)
+* [Precautionary Notes](#precautionary-notes)
 * [Development](#development)
 * [Further Reading](#further-reading)
 
@@ -420,6 +421,9 @@ there was a request
 there was a response
 >
 ```
+
+## Precautionary Notes
+Any `content-length` header passed into the request options will be removed as a precaution against mismatching content-length values downstream. In the case of a non-buffer payload, this can occur if escape characters were taken into consideration when calculating the content length. This mismatch will result in the downstream service waiting for bytes that will never be sent. By removing the header, we defer to Wreck to calculate the correct content length.
 
 ## Development
 This package uses [`debug`](https://github.com/visionmedia/debug) for logging debug statements.

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -193,6 +193,15 @@ const create = async function (method, path, options, hooks = {}) {
     path += `?${QueryString.stringify(options.queryParams)}`
   }
 
+  // Remove 'content-length' from request headers.
+  // If the payload is not a buffer, this value may have been calculated before any
+  // escaping took place, resulting in a content-length mismatch. This will result
+  // in the downstream service waiting for bytes that will never be sent.
+  // By doing this, we defer to Wreck to calculate the content length.
+  if (options.headers) {
+    delete options.headers['content-length']
+  }
+
   debug('create(): invoking request')
 
   try {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "eslint lib test",
     "mocha": "mocha test/unit/*.js test/unit/**/*.js",
     "nyc": "nyc --reporter=text --reporter=text-summary --reporter=html --report-dir=docs/reports/coverage npm run mocha",
-    "postnyc": "nyc check-coverage --statements 99 --branches 97 --functions 100 --lines 99"
+    "postnyc": "nyc check-coverage --statements 100 --branches 97 --functions 100 --lines 100"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change prevents a scenario where the value in the content-length header does not match that of the actual payload. In the case of a non-buffer payload, this can occur if escape characters were taken into consideration when calculating the content length. This mismatch will result in the downstream service waiting for bytes that will never be sent. By removing the header, we defer to Wreck to calculate the correct content length.