### PR TITLE
Fix: Resolve client plugin config and per-request plugin config

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -26,12 +26,27 @@ async function init (options) {
   const hooks = {}
 
   /*
-    First build up an object of hook names mapped to an array of associated hook functions
-    {
-        'request': [hookFn1, hookFn1],
-        ...
+  First merge the client plugin config with the per-request plugin config
+  */
+  const pluginOptions = Object.assign({}, options.client.config('plugins'))
+  const perRequestPluginOptions = options.plugins
+  Object.keys(perRequestPluginOptions).forEach((name) => {
+    const opts = perRequestPluginOptions[name]
+    if (typeof opts === 'object') {
+      pluginOptions[name] = Object.assign({}, pluginOptions[name], opts)
+    } else {
+      pluginOptions[name] = opts
     }
-    */
+  })
+  options.plugins = pluginOptions
+
+  /*
+  Then build up an object of hook names mapped to an array of associated hook functions
+  {
+    'request': [hookFn1, hookFn1],
+    ...
+  }
+  */
   // process plugin initialization in parallel
   const pluginPromises = []
   GlobalConfig.plugins.forEach((plugin) => {
@@ -51,15 +66,15 @@ async function init (options) {
   })
 
   /*
-    Now that we have this map of hook names to hook functions, replace each
-    array with a function that will resolve each of the functions in the array.
-    {
-        'request': async function() {
-            await Promise.all([hookFn1(), hookFn2()])
-        },
-        ...
-    }
-    */
+  Now that we have this map of hook names to hook functions, replace each
+  array with a function that will resolve each of the functions in the array.
+  {
+    'request': async function() {
+        await Promise.all([hookFn1(), hookFn2()])
+    },
+    ...
+  }
+  */
   Object.entries(hooks).forEach(([hookName, hookFns]) => {
     hooks[hookName] = async function (data) {
       debug('%s(): calling %d hooks', hookName, hookFns.length)

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ const create = function (servicename, overrides = {}) {
 
   const config = Schema.validateCreate(merged)
 
-  /* istanbul ignore else */
+  // istanbul ignore else */
   if (!config.agent) {
     config.agent = Agent.create(config.protocol, config)
   }
@@ -51,7 +51,7 @@ const use = function (plugins = []) {
   }
 
   plugins.forEach((plugin) => {
-    /* istanbul ignore else */
+    // istanbul ignore else
     if (typeof plugin === 'function' && !GlobalConfig.plugins.includes(plugin)) {
       GlobalConfig.plugins.push(plugin)
     }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "npm run eslint && npm run nyc",
     "eslint": "eslint lib test",
     "mocha": "mocha test/unit/*.js test/unit/**/*.js",
-    "nyc": "nyc --reporter=text --reporter=text-summary --reporter=html --report-dir=docs/reports/coverage npm run mocha",
+    "nyc": "nyc --reporter=text --reporter=text-summary --reporter=lcov --report-dir=docs/reports/coverage npm run mocha",
     "postnyc": "nyc check-coverage --statements 100 --branches 97 --functions 100 --lines 100"
   },
   "repository": {

--- a/test/unit/hooks/index.test.js
+++ b/test/unit/hooks/index.test.js
@@ -69,7 +69,7 @@ describe('Hooks', () => {
         )
       })
 
-      it('should set per-request plugin options to false', async function () {
+      it('should disable a configured plugin', async function () {
         const hookOptions = {
           client: {
             config: () => ({
@@ -96,7 +96,7 @@ describe('Hooks', () => {
         })
       })
 
-      it('should set per-request plugin options to false', async function () {
+      it('should enable a disabled plugin', async function () {
         const hookOptions = {
           client: {
             config: () => ({

--- a/test/unit/hooks/index.test.js
+++ b/test/unit/hooks/index.test.js
@@ -37,12 +37,121 @@ describe('Hooks', () => {
         () => plugin2
       )
 
-      const options = {}
-      const result = await Hooks.init(options)
+      const hookOptions = {
+        client: {
+          config () {}
+        },
+        context: null,
+        plugins: {}
+      }
+      const result = await Hooks.init(hookOptions)
 
       assert.typeOf(result.request, 'function')
       assert.typeOf(result.init, 'function')
       assert.typeOf(result.response, 'function')
+    })
+
+    describe('per-request plugin options', function () {
+      beforeEach(function () {
+        suite.plugin1Stub = suite.sandbox.stub().returns({
+          request () {},
+          init () {}
+        })
+
+        suite.plugin2Stub = suite.sandbox.stub().returns({
+          request () {},
+          init () {}
+        })
+
+        GlobalConfig.plugins.push(
+          suite.plugin1Stub,
+          suite.plugin2Stub
+        )
+      })
+
+      it('should set per-request plugin options to false', async function () {
+        const hookOptions = {
+          client: {
+            config: () => ({
+              auth: {
+                clientId: '123',
+                clientSecret: 'abc'
+              }
+            })
+          },
+          context: null,
+          plugins: {
+            auth: false
+          }
+        }
+
+        await Hooks.init(hookOptions)
+
+        Sinon.assert.calledWith(suite.plugin1Stub, {
+          client: Sinon.match.any,
+          context: Sinon.match.any,
+          plugins: Sinon.match({
+            auth: false
+          })
+        })
+      })
+
+      it('should set per-request plugin options to false', async function () {
+        const hookOptions = {
+          client: {
+            config: () => ({
+              foobar: false
+            })
+          },
+          context: null,
+          plugins: {
+            foobar: true
+          }
+        }
+
+        await Hooks.init(hookOptions)
+
+        Sinon.assert.calledWith(suite.plugin1Stub, {
+          client: Sinon.match.any,
+          context: Sinon.match.any,
+          plugins: Sinon.match({
+            foobar: true
+          })
+        })
+      })
+
+      it('should use options containing base and per-request config', async function () {
+        const hookOptions = {
+          client: {
+            config: () => ({
+              auth: {
+                clientId: '123',
+                clientSecret: 'abc'
+              }
+            })
+          },
+          context: null,
+          plugins: {
+            auth: {
+              initialRetry: true
+            }
+          }
+        }
+
+        await Hooks.init(hookOptions)
+
+        Sinon.assert.calledWith(suite.plugin1Stub, {
+          client: Sinon.match.any,
+          context: Sinon.match.any,
+          plugins: Sinon.match({
+            auth: {
+              clientId: '123',
+              clientSecret: 'abc',
+              initialRetry: true
+            }
+          })
+        })
+      })
     })
 
     it('should execute each added hook', async function () {
@@ -61,8 +170,14 @@ describe('Hooks', () => {
         () => plugin2
       )
 
-      const options = {}
-      const result = await Hooks.init(options)
+      const hookOptions = {
+        client: {
+          config () {}
+        },
+        context: null,
+        plugins: {}
+      }
+      const result = await Hooks.init(hookOptions)
 
       const data = { options: { foo: 'bar' } }
       result.request(data)
@@ -117,8 +232,14 @@ describe('Hooks', () => {
 
       const startTime = Date.now()
 
-      const options = {}
-      const result = await Hooks.init(options)
+      const hookOptions = {
+        client: {
+          config () {}
+        },
+        context: null,
+        plugins: {}
+      }
+      const result = await Hooks.init(hookOptions)
 
       const data = { options: { foo: 'bar' } }
       await result.request(data)


### PR DESCRIPTION
Base plugin configuration was not being taken into consideration when passing options to each plugin hook on each request. This PR resolves the two, correctly merging the per-request options with the global and per-client plugin options.